### PR TITLE
APIS-7285: Optimise deskpro import for normal runs

### DIFF
--- a/app/uk/gov/hmrc/apiplatformdeskpro/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/apiplatformdeskpro/config/AppConfig.scala
@@ -36,5 +36,5 @@ class AppConfig @Inject() (config: ServicesConfig) {
   val thirdPartyDeveloperUrl: String = config.baseUrl("third-party-developer")
   val deskproBatchSize: Int          = config.getInt("importUser.deskpro-batch-size")
   val deskproBatchPause: Int         = config.getInt("importUser.deskpro-batch-pause")
-
+  val initialImport: Boolean         = config.getBoolean("importUser.initial-import")
 }

--- a/app/uk/gov/hmrc/apiplatformdeskpro/connector/DeveloperConnector.scala
+++ b/app/uk/gov/hmrc/apiplatformdeskpro/connector/DeveloperConnector.scala
@@ -50,10 +50,10 @@ class DeveloperConnector @Inject() (http: HttpClientV2, config: AppConfig, metri
 
     http.get(url"${requestUrl("/developers")}?$queryParams")
       .execute[List[RegisteredUser]]
-      .map(users => {
-        if (users.isEmpty) logger.info("No Users Returned from DeveloperConnector")
+      .map { users =>
+        logger.info(s"${users.size} user(s) returned from DeveloperConnector")
         users
-      })
+      }
   }
 
   private def requestUrl[B, A](uri: String): String = s"$serviceBaseUrl$uri"

--- a/app/uk/gov/hmrc/apiplatformdeskpro/connector/DeveloperConnector.scala
+++ b/app/uk/gov/hmrc/apiplatformdeskpro/connector/DeveloperConnector.scala
@@ -17,8 +17,9 @@
 package uk.gov.hmrc.apiplatformdeskpro.connector
 
 import java.time._
+import java.time.format.DateTimeFormatter
 import javax.inject.Inject
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 
 import uk.gov.hmrc.apiplatformdeskpro.config.AppConfig
 import uk.gov.hmrc.apiplatformdeskpro.domain.models.connector.RegisteredUser
@@ -35,10 +36,17 @@ class DeveloperConnector @Inject() (http: HttpClientV2, config: AppConfig, metri
   lazy val serviceBaseUrl: String = config.thirdPartyDeveloperUrl
   val api                         = API("third-party-developer")
 
-  def searchDevelopers()(implicit hc: HeaderCarrier) = metrics.record(api) {
-    val queryParams = Seq(
-      "status" -> "VERIFIED"
-    )
+  def searchDevelopers(daysToLookBack: Option[Int] = None)(implicit hc: HeaderCarrier): Future[List[RegisteredUser]] = metrics.record(api) {
+    val queryParams = daysToLookBack match {
+      case Some(days) => Seq(
+          "status"       -> "VERIFIED",
+          "createdAfter" -> DateTimeFormatter.BASIC_ISO_DATE.format(now().toLocalDate.minusDays(days))
+        )
+      case None       => Seq(
+          "status" -> "VERIFIED"
+        )
+    }
+
     http.get(url"${requestUrl("/developers")}?$queryParams")
       .execute[List[RegisteredUser]]
       .map(users => {

--- a/app/uk/gov/hmrc/apiplatformdeskpro/connector/DeveloperConnector.scala
+++ b/app/uk/gov/hmrc/apiplatformdeskpro/connector/DeveloperConnector.scala
@@ -40,6 +40,7 @@ class DeveloperConnector @Inject() (http: HttpClientV2, config: AppConfig, metri
     val queryParams = daysToLookBack match {
       case Some(days) => Seq(
           "status"       -> "VERIFIED",
+          "limit"        -> 10000,
           "createdAfter" -> DateTimeFormatter.BASIC_ISO_DATE.format(now().toLocalDate.minusDays(days))
         )
       case None       => Seq(

--- a/app/uk/gov/hmrc/apiplatformdeskpro/domain/models/DeskproPersonCreation.scala
+++ b/app/uk/gov/hmrc/apiplatformdeskpro/domain/models/DeskproPersonCreation.scala
@@ -20,4 +20,3 @@ sealed trait DeskproPersonCreationResult
 object DeskproPersonCreationSuccess extends DeskproPersonCreationResult
 object DeskproPersonCreationFailure extends DeskproPersonCreationResult
 object DeskproPersonExistsInDeskpro extends DeskproPersonCreationResult
-object DeskproPersonExistsInDb      extends DeskproPersonCreationResult

--- a/app/uk/gov/hmrc/apiplatformdeskpro/repository/MigratedUserRepository.scala
+++ b/app/uk/gov/hmrc/apiplatformdeskpro/repository/MigratedUserRepository.scala
@@ -71,8 +71,8 @@ class MigratedUserRepository @Inject() (mongo: MongoComponent, val clock: Clock)
     }
   }
 
-  def findByUserId(userId: UserId): Future[Option[MigratedUser]] = {
-    collection.find(Filters.eq("userId", Codecs.toBson(userId))).headOption()
+  def userExists(userId: UserId): Future[Boolean] = {
+    collection.find(Filters.eq("userId", Codecs.toBson(userId))).headOption().map(_.isDefined)
   }
 
 }

--- a/app/uk/gov/hmrc/apiplatformdeskpro/scheduled/CreatePersonService.scala
+++ b/app/uk/gov/hmrc/apiplatformdeskpro/scheduled/CreatePersonService.scala
@@ -47,8 +47,10 @@ class CreatePersonService @Inject() (
 
   def pushNewUsersToDeskpro()(implicit ec: ExecutionContext): Future[Unit] = {
     for {
-      users          <- developerConnector.searchDevelopers(if (config.initialImport) None else (Some(daysToLookBackInNormalRun)))
+      users          <- developerConnector.searchDevelopers(if (config.initialImport) None else Some(daysToLookBackInNormalRun))
+                          .map(u => { logger.info(s"${u.size} user(s) retrieved from TPD"); u })
       usersToMigrate <- filterMigratedUsers(users)
+                          .map(utm => { logger.info(s"${utm.size} user(s) to migrate"); utm })
       results        <- batchFutures(config.deskproBatchSize, config.deskproBatchPause, pushUserToDeskpro)(usersToMigrate)
     } yield results
   }

--- a/app/uk/gov/hmrc/apiplatformdeskpro/scheduled/CreatePersonService.scala
+++ b/app/uk/gov/hmrc/apiplatformdeskpro/scheduled/CreatePersonService.scala
@@ -43,7 +43,7 @@ class CreatePersonService @Inject() (
   ) extends ApplicationLogger with ClockNow {
 
   implicit val hc: HeaderCarrier = HeaderCarrier()
-  val daysToLookBackInNormalRun  = 30
+  val daysToLookBackInNormalRun  = 31
 
   def pushNewUsersToDeskpro()(implicit ec: ExecutionContext): Future[Unit] = {
     for {

--- a/app/uk/gov/hmrc/apiplatformdeskpro/scheduled/ImportNewUsersToDeskProJob.scala
+++ b/app/uk/gov/hmrc/apiplatformdeskpro/scheduled/ImportNewUsersToDeskProJob.scala
@@ -56,6 +56,7 @@ class ImportNewUsersToDeskProJob @Inject() (
     actorSystem.scheduler.scheduleWithFixedDelay(initialDelay, interval) { () =>
       // now use the lock
       lockService.withLock {
+        logger.info(s"Acquired lock. Starting ImportNewUsersToDeskProJob run")
         createPersonService.pushNewUsersToDeskpro()
       }.map {
         case Some(res) => logger.info(s"Finished with $res. Lock has been released.")

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -72,9 +72,9 @@ mongodb {
 importUser {
     initialDelay=10s
     interval=6h
-    enabled=true
-    deskpro-batch-size=100
-    deskpro-batch-pause=1000
+    enabled=false
+    deskpro-batch-size=1
+    deskpro-batch-pause=500
     initial-import = true
 }
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -75,7 +75,7 @@ importUser {
     enabled=false
     deskpro-batch-size=100
     deskpro-batch-pause=1000
-    initial-import = true
+    initial-import = false
 }
 
 microservice {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -75,6 +75,7 @@ importUser {
     enabled=false
     deskpro-batch-size=100
     deskpro-batch-pause=1000
+    initial-import = true
 }
 
 microservice {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -72,10 +72,10 @@ mongodb {
 importUser {
     initialDelay=10s
     interval=6h
-    enabled=false
+    enabled=true
     deskpro-batch-size=100
     deskpro-batch-pause=1000
-    initial-import = false
+    initial-import = true
 }
 
 microservice {

--- a/it/test/uk/gov/hmrc/apiplatformdeskpro/connector/DeveloperConnectorISpec.scala
+++ b/it/test/uk/gov/hmrc/apiplatformdeskpro/connector/DeveloperConnectorISpec.scala
@@ -68,6 +68,7 @@ class DeveloperConnectorISpec extends AsyncHmrcSpec
       stubFor(
         get(urlPathEqualTo("/developers"))
           .withQueryParam("status", equalTo("VERIFIED"))
+          .withQueryParam("limit", equalTo("10000"))
           .withQueryParam("createdAfter", equalTo(DateTimeFormatter.BASIC_ISO_DATE.format(now.minusDays(days))))
           .willReturn(
             aResponse()

--- a/it/test/uk/gov/hmrc/apiplatformdeskpro/connector/DeveloperConnectorISpec.scala
+++ b/it/test/uk/gov/hmrc/apiplatformdeskpro/connector/DeveloperConnectorISpec.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.apiplatformdeskpro.connector
 
 import java.time._
+import java.time.format.DateTimeFormatter
 
 import com.github.tomakehurst.wiremock.client.WireMock._
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
@@ -63,6 +64,19 @@ class DeveloperConnectorISpec extends AsyncHmrcSpec
       )
     }
 
+    def stubGetDevelopersWithDaysToLookBackSuccess(days: Int) = {
+      stubFor(
+        get(urlPathEqualTo("/developers"))
+          .withQueryParam("status", equalTo("VERIFIED"))
+          .withQueryParam("createdAfter", equalTo(DateTimeFormatter.BASIC_ISO_DATE.format(now.minusDays(days))))
+          .willReturn(
+            aResponse()
+              .withBody("""[{"email":"bob.hope@business.com","userId":"6f0c4afa-1e10-44a1-8538-f5d436e7b615", "firstName":"Bob", "lastName":"Hope"},{"email":"emu.hull@business.com","userId":"a86857b3-732a-41c7-8d37-d29d5f416404", "firstName":"Emu", "lastName":"Hull"}]""")
+              .withStatus(OK)
+          )
+      )
+    }
+
     def stubGetDevelopersEmptyList() = {
       stubFor(
         get(urlPathEqualTo("/developers"))
@@ -91,6 +105,16 @@ class DeveloperConnectorISpec extends AsyncHmrcSpec
       stubGetDevelopersSuccess()
 
       val result = await(objInTest.searchDevelopers())
+      result shouldBe List(
+        RegisteredUser(LaxEmailAddress("bob.hope@business.com"), UserId.unsafeApply("6f0c4afa-1e10-44a1-8538-f5d436e7b615"), "Bob", "Hope"),
+        RegisteredUser(LaxEmailAddress("emu.hull@business.com"), UserId.unsafeApply("a86857b3-732a-41c7-8d37-d29d5f416404"), "Emu", "Hull")
+      )
+    }
+
+    "return list of registered users from TPD when daysToLookBack is specified" in new Setup {
+      stubGetDevelopersWithDaysToLookBackSuccess(5)
+
+      val result = await(objInTest.searchDevelopers(Some(5)))
       result shouldBe List(
         RegisteredUser(LaxEmailAddress("bob.hope@business.com"), UserId.unsafeApply("6f0c4afa-1e10-44a1-8538-f5d436e7b615"), "Bob", "Hope"),
         RegisteredUser(LaxEmailAddress("emu.hull@business.com"), UserId.unsafeApply("a86857b3-732a-41c7-8d37-d29d5f416404"), "Emu", "Hull")

--- a/it/test/uk/gov/hmrc/apiplatformdeskpro/repository/MigratedUserRepositoryISpec.scala
+++ b/it/test/uk/gov/hmrc/apiplatformdeskpro/repository/MigratedUserRepositoryISpec.scala
@@ -58,18 +58,15 @@ class MigratedUserRepositoryISpec extends AsyncHmrcSpec
     }
 
     "findByUserId" should {
-
       "findUser when exists in db" in {
         val migratedUser = MigratedUser(LaxEmailAddress("newUser@compny.com"), UserId.random, Instant.now(clock))
         await(migratedUserRepository.saveMigratedUser(migratedUser))
 
-        val result: Option[MigratedUser] = await(migratedUserRepository.findByUserId(migratedUser.userId))
-        result shouldBe Some(migratedUser)
+        await(migratedUserRepository.userExists(migratedUser.userId)) shouldBe true
       }
 
-      "not find anything when user not in db" in {
-        val result: Option[MigratedUser] = await(migratedUserRepository.findByUserId(UserId.random))
-        result shouldBe None
+      "not find user not in db" in {
+        await(migratedUserRepository.userExists(UserId.random)) shouldBe false
       }
     }
   }


### PR DESCRIPTION
 - Refactor request throttling to only apply to deskpro requests.
 - Add initial-import mode to query TPD for all users only on initial import, otherwise to only look back 30 days (max time allowed for users to verify)